### PR TITLE
Make the project compatible with Exponent

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,3 +1,0 @@
-{
-  "plugins": ["transform-object-rest-spread"]
-}

--- a/Readme.MD
+++ b/Readme.MD
@@ -5,6 +5,8 @@
 
 ## Get Started
 
+*If you are using Exponent, you can run* `npm i react-native-elements --save` *and skip to step 5.**
+
 #### Step 1
 
 Install rnpm if not already installed on your machine

--- a/Readme.MD
+++ b/Readme.MD
@@ -5,25 +5,31 @@
 
 ## Get Started
 
-#### Step 1 
+#### Step 1
 
 Install rnpm if not already installed on your machine
 
 `npm install rnpm -g`
 
-####Step 2
+#### Step 2
+
+Install react-native-vector-icons (if you do not already have it)
+
+`npm i react-native-elements --save && rnpm link react-native-vector-icons`
+
+### Step 3
 
 Install React Native Elements
 
 `npm i react-native-elements --save`
 
-Step 3
+### Step 4
 
 Link project
 
 `rnpm link`
 
-Step 4
+### Step 5
 
 Start using components
 

--- a/Readme.MD
+++ b/Readme.MD
@@ -5,7 +5,7 @@
 
 ## Get Started
 
-*If you are using Exponent, you can run* `npm i react-native-elements --save` *and skip to step 5.**
+*If you are using Exponent, you can run* `npm i react-native-elements github:exponentjs/react-native-vector-icons --save` *and skip to step 5.**
 
 #### Step 1
 

--- a/Readme.MD
+++ b/Readme.MD
@@ -76,7 +76,7 @@ Check out the pre built and configured [React Native Hackathon Starter Project](
 ## Notes
 
 #### Fonts
-React Native Elements uses Lato as the default font family for iOS and Roboto as the default font family for Android.
+React Native Elements uses Helvetica Neue as the default font family for iOS and Roboto as the default font family for Android.
 
 > We are working on a way to make the font family configurable through the command line.
 
@@ -126,7 +126,7 @@ import { Button } from 'react-native-elements'
 | buttonStyle | none | object (style) | add additional styling for button component (optional) |
 | title | none | string | button title (required) |
 | small | false | boolean | makes button small |
-| fontFamily | Lato (iOS), Roboto (android) | string | specify different font family |
+| fontFamily | HelveticaNeue (iOS), Roboto (android) | string | specify different font family |
 | iconRight | false | boolean | moves icon to right of title |
 | onPress | none | function | onPress method (required) |
 | icon | none | object {name(string), color(string), size(number)} | [Material Icon Name](https://design.google.com/icons/) (optional) | 
@@ -172,7 +172,7 @@ import { SocialIcon } from 'react-native-elements'
 | style | none | object (style) | button styling (optional) |
 | iconColor | white | string | icon color (optional) |
 | component | TouchableHighlight | React Native Component | type of button (optional)  |
-| fontFamily | Lato-Black (iOS), Roboto-Black (android) | string | specify different font family |
+| fontFamily | HelveticaNeue-CondensedBlack (iOS), Roboto-Black (android) | string | specify different font family |
 | fontStyle | none | object (style) | specify text styling |
 
 ## Lists
@@ -278,7 +278,7 @@ render () {
 | titleStyle | none | object (style) | additional title styling (optional) |
 | wrapperStyle | none | object (style) | additional wrapper styling (optional) |
 | underlayColor | white | string | define underlay color for TouchableHighlight (optional) |
-| fontFamily | Lato (iOS), Roboto (android) | string | specify different font family |
+| fontFamily | HelevticaNeue (iOS), Roboto (android) | string | specify different font family |
 
 
 ## SideMenu
@@ -402,7 +402,7 @@ import { CheckBox } from 'react-native-elements'
 | checkedColor | green | string | default checked color (optional) |
 | uncheckedColor | #bfbfbf | string | default unchecked color (optional) |
 | checkedTitle | none | string | specify a custom checked message (optional) |
-| fontFamily | Lato-Bold (iOS), Roboto-Bold (android) | string | specify different font family |
+| fontFamily | HelveticaNeue-Bold (iOS), Roboto-Bold (android) | string | specify different font family |
 
 ## Forms
 
@@ -431,7 +431,7 @@ import { FormLabel, FormInput } from 'react-native-elements'
 | ---- | ---- | ----| ---- |
 | containerStyle | none | object (style) | additional label container style (optional) |
 | labelStyle | none | object (style) | additional label styling (optional) |
-| fontFamily | Lato-Bold (iOS), Roboto-Bold (android) | string | specify different font family |
+| fontFamily | HelveticaNeue-Bold (iOS), Roboto-Bold (android) | string | specify different font family |
 
 
 ## Card
@@ -459,7 +459,7 @@ import { Card } from 'react-native-elements'
 | title | none | string | optional card title (optional) |
 | titleStyle | none | object (style) | additional title styling (if title provided) (optional) |
 | dividerStyle | none | object (style) | additional divider styling (if title provided) (optional) |
-| fontFamily | Lato-Bold (iOS), Roboto-Bold (android) | string | specify different font family |
+| fontFamily | HelveticaNeue-Bold (iOS), Roboto-Bold (android) | string | specify different font family |
 
 
 ## Pricing Component
@@ -490,10 +490,10 @@ import { PricingCard } from 'react-native-elements'
 | button | none | object {title, icon, buttonStyle} | button information (required) |
 | containerStyle | inherited styling | object (style) | outer component styling (optional) |
 | wrapperStyle | inherited styling | object (style) | inner wrapper component styling (optional) |
-| titleFont | Lato-Black (iOS), Roboto-Black (android) | string | specify title font family |
-| pricingFont | Lato-Bold (iOS), Roboto-Bold (android) | string | specify pricing font family |
-| infoFont | Lato-Bold (iOS), Roboto-Bold (android) | string | specify pricing information font family |
-| buttonFont | Lato (iOS), Roboto (android) | string | specify button font family |
+| titleFont | HelveticaNeue-CondensedBlack (iOS), Roboto-Black (android) | string | specify title font family |
+| pricingFont | HelveticaNeue-Bold (iOS), Roboto-Bold (android) | string | specify pricing font family |
+| infoFont | HelveticaNeue-Bold (iOS), Roboto-Bold (android) | string | specify pricing information font family |
+| buttonFont | HelveticaNeue (iOS), Roboto (android) | string | specify button font family |
   
 
 

--- a/package.json
+++ b/package.json
@@ -2,11 +2,7 @@
   "name": "react-native-elements",
   "version": "0.3.2",
   "description": "React Native Elements & UI Toolkit",
-  "main": "dist/index.js",
-  "scripts": {
-    "build": "babel src --out-dir dist --presets es2015,react",
-    "watch": "babel src --out-dir dist --watch --presets es2015,react"
-  },
+  "main": "src/index.js",
   "repository": {
     "type": "git",
     "url": "git+ssh://git@github.com/dabit3/React-Native-Elements.git"
@@ -19,12 +15,6 @@
   ],
   "peerDependencies": {
     "react-native-vector-icons": "^2.1.0"
-  },
-  "devDependencies": {
-    "babel-cli": "^6.11.4",
-    "babel-plugin-transform-object-rest-spread": "^6.8.0",
-    "babel-preset-es2015": "^6.13.2",
-    "babel-preset-react": "^6.11.1"
   },
   "author": "Nader Dabit",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,8 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "build": "babel src --out-dir dist --presets es2015,react",
-    "watch": "babel src --out-dir dist --watch --presets es2015,react",
-    "postinstall": "rnpm link react-native-vector-icons"
+    "watch": "babel src --out-dir dist --watch --presets es2015,react"
   },
   "repository": {
     "type": "git",
@@ -18,13 +17,8 @@
     "reactnative",
     "bootstrap"
   ],
-  "dependencies": {
+  "peerDependencies": {
     "react-native-vector-icons": "^2.1.0"
-  },
-  "rnpm": {
-    "assets": [
-      "Fonts"
-    ]
   },
   "devDependencies": {
     "babel-cli": "^6.11.4",

--- a/src/config/fonts.js
+++ b/src/config/fonts.js
@@ -1,12 +1,11 @@
 export default {
   ios: {
-    regular: 'Lato',
-    light: 'Lato-Light',
-    lightItalic: 'Lato-LightItalic',
-    bold: 'Lato-Bold',
-    boldItalic: 'Lato-BoldItalic',
-    black: 'Lato-Black',
-    blackItalic: 'Lato-BlackItalic'
+    regular: 'HelveticaNeue',
+    light: 'HelveticaNeue-Light',
+    lightItalic: 'HelveticaNeue-LightItalic',
+    bold: 'HelveticaNeue-Bold',
+    boldItalic: 'HelveticaNeue-BoldItalic',
+    black: 'HelveticaNeue-CondensedBlack',
   },
   android: {
     regular: 'Roboto',


### PR DESCRIPTION
- Removes hard dependency on react-native-vector-icons and instead makes it a peerDependency, so we can substitute our own implementation that works with Exponent.
- Ship uncompiled code for now as it's quite a small project and makes it easier to debug issues by editing it inside of your node_modules (we went back from shipping compiled code for ex-navigation as well because it was a hassle for users)
- Switch from Lato to HelveticaNeue on iOS by default.

Let me know if you're OK with these changes or if there are other approaches you'd prefer. Looking like a really great project so far, thanks @dabit3!